### PR TITLE
update urls for evergreenhud & remove warning

### DIFF
--- a/files/mods.json
+++ b/files/mods.json
@@ -307,7 +307,7 @@
             "evergreen"
         ],
         "file": "EvergreenHUD (1.8.9-2.0-RC.3).jar",
-        "url": "https://short.isxander.co.uk/RqjzS4",
+        "url": "https://short.isxander.dev/RqjzS4",
         "display": "EvergreenHUD",
         "description": "Displays every piece of information a Minecraft player could ever need.",
         "creator": "isXander",
@@ -318,22 +318,14 @@
             {
                 "icon": "github.png",
                 "text": "Github",
-                "link": "https://short.isxander.co.uk/WD21Ce"
+                "link": "https://short.isxander.dev/WD21Ce"
             },
             {
                 "icon": "forum.png",
                 "text": "Hypixel",
                 "link": "https://hypixel.net/threads/3787277/"
             }
-        ],
-        "warning": {
-            "lines": [
-                "This mod is currently in the release candidate stage. This means that it should be pretty stable by now.",
-                "KEYWORD: SHOULD. You may still encounter stability problems.",
-                "",
-                "Use anyway?"
-            ]
-        }
+        ]
     },
     {
         "id": "neu",


### PR DESCRIPTION
I also removed the warning because other mods like NEU are using prerelease builds with no warning so I feel it is unfair.