### PR TITLE
free nitro only sign in with your steam account to claim free nitro

### DIFF
--- a/files/scamlinks.json
+++ b/files/scamlinks.json
@@ -894,5 +894,6 @@
     "stearncommuty.com",
     "dlscord.wiki",
     "oligarph.club",
-    "made-nitro.com"
+    "made-nitro.com",
+    "dirscod.com"
 ]


### PR DESCRIPTION
working 2021 confirmed no virus