### PR TITLE
add hytilities reborn

### DIFF
--- a/files/guides/hytilities-reborn.md
+++ b/files/guides/hytilities-reborn.md
@@ -1,0 +1,16 @@
+# Hytilities Reborn Guide
+
+## How do I use Hytilities Reborn?
+> to enable and disable features, type in either `/hytilities` or `/hytils` in chat. Then configure the settings there. 
+
+## Some features require an API key (such as the GEXP and winstreak command).
+> to add an API key, either type in `/api new` in chat, or type in `/hytilities setkey [key]`.
+
+## How do I see all the features?
+> You can either look in the config GUI or go here (https://github.com/W-OVERFLOW/Hytilities-Reborn/blob/master/README.md) and select the user guide.
+
+### How do I get support for Hytilities?
+> to get support for Hytilities, go to the W-OVERFLOW discord server (https://inv.wtf/w-overflow) and type your issue / send a crash log in the #support channel.
+
+### To get help on commands, type this in chat:
+> `/hytilities help`

--- a/files/guides/wyvtils.md
+++ b/files/guides/wyvtils.md
@@ -7,7 +7,7 @@
 > to add an API key, either type in `/api new` in chat, or type in `/wyvtils setkey [key]`.
 
 ### How do I get support for Wyvtils?
-> to get support for Wyvtils, go to the Qalcyo discord server (https://inv.wtf/qalcyo) and type your issue / send a crash log in the #support channel.
+> to get support for Wyvtils, go to the W-OVERFLOW discord server (https://inv.wtf/w-overflow) and type your issue / send a crash log in the #support channel.
 
 ### To get help on commands, type this in chat:
 > `/wyvtils help`

--- a/files/mods.json
+++ b/files/mods.json
@@ -624,6 +624,30 @@
         ]
     },
     {
+        "id": "hytilities-reborn",
+        "forge_id": "hytilities-reborn",
+        "file": "Hytilities-Reborn-1.0.0.jar",
+        "url": "https://github.com/W-OVERFLOW/Hytilities-Reborn/releases/download/v1.0.0/Hytilities-Reborn-1.0.0.jar",
+        "display": "Hytilities Reborn",
+        "description": "Hytilities Reborn is a Hypixel focused Forge 1.8.9 mod based on Sk1er LLC's Hytilities, adding tons of Quality of Life features that you would want while on Hypixel, such as an Advertisement-Blocker, AutoQueue, AutoGL, Height Overlay, Game Status Restyle, AutoComplete for /play and plenty others to discover on your own!",
+        "icon": "wyvest.png",
+        "command": "/hytilities",
+        "creator": "W-OVERFLOW (Wyvest)",
+        "actions": [
+            {
+                "icon": "github.png",
+                "text": "Github",
+                "link": "https://github.com/W-OVERFLOW/Hytilities-Reborn"
+            },
+            {
+                "icon": "guide.png",
+                "text": "Guide",
+                "link": "https://github.com/nacrt/SkyblockClient-REPO/blob/main/files/guides/hytilities-reborn.md"
+            }
+        ],
+        "discordcode": "qKETDJDsV3"
+    },
+    {
         "id": "keystrokes",
         "forge_id": "keystrokesmod",
         "file": "Keystrokes-8.1.2 (1.8.9).jar",
@@ -713,7 +737,7 @@
         "description": "Adds multiple utilities for Hypixel 1.8.9, such as bossbar customization (which isn't made using 2019 code), sidebar customization, action bar customization, title resizer, hitbox customization, a name highlighter, and more.",
         "icon": "wyvest.png",
         "command": "/wyvtils",
-        "creator": "Wyvest",
+        "creator": "W-OVERFLOW (Wyvest)",
         "actions": [
             {
                 "icon": "github.png",


### PR DESCRIPTION
this pr adds hytils reborn

why hytils reborn should be in skyclient
- it is for Hypixel in general
- it has some skyblock specific features (Remove the Skyblock Welcome Message, Cleaner Tab in Skyblock)