### PR TITLE
add betterhurtcam

### DIFF
--- a/files/mods.json
+++ b/files/mods.json
@@ -525,6 +525,35 @@
         ]
     },
     {
+        "id": "betterhurtcam",
+        "forge_id": "betterhurtcam",
+        "icon": "wyvest.png",
+        "file": "BetterHurtCam-2.1.3.jar",
+        "hash": "3afaf5b1c2472bb03c2f1b7885f61d0c5fa6196c79259b443effcb47c46b521f",
+        "url": "https://github.com/W-OVERFLOW/BetterHurtCam/releases/download/v2.1.3/BetterHurtCam-2.1.3.jar",
+        "display": "BetterHurtCam",
+        "creator": "W-OVERFLOW (Salmon)",
+        "command": "/betterhurtcam",
+        "actions": [
+            {
+                "icon": "github.png",
+                "text": "GitHub",
+                "link": "https://github.com/W-OVERFLOW/BetterHurtCam"
+            },
+            {
+                "icon": "youtube.png",
+                "text": "Showcase",
+                "link": "https://www.youtube.com/watch?v=F3Mg3-FPvQs"
+            }
+        ],
+        "discordcode": "woverflow",
+        "description": "Increase or decrease the hurtcam when hit.",
+        "categories": [
+            "4;All PvP",
+            "5;Recommended PvP"
+        ]
+    },
+    {
         "id": "nick_hider",
         "nicknames": [
             "nickhider"


### PR DESCRIPTION
add betterhurtcam

**allowance in hypixel**
as stated in the README of the mod, the mininum hurtcam of the mod is set to 6, which is the same / similar to lunar's reduced hurtcam amount. seeing as lunar has no need to disable this on hypixel despite them taking action by themselves on other mods such as their particle mod, hypixel does not care about modifications that modify the hurtcam.