### PR TITLE
Updated auto response for 1.7 animations

### DIFF
--- a/files/botautoresponse.json
+++ b/files/botautoresponse.json
@@ -201,7 +201,7 @@
                 "anim"
             ]
         ],
-        "response": "Use sk1ers old animations https://sk1er.club/beta"
+        "response": "Use sk1ers old animations, as it's the one of the best *(if not best)* mod for 1.7 animations.\nAfter joining head to <#958820675106267207> to get access, and then head to <#958820495631999046> to find the installation for the 1.7 animations mod.  *the channels should show up as `#deleted-channel` if you're not in the server* \n discord.gg/sk1er"
     },
     {
         "triggers": [


### PR DESCRIPTION
Since sk1er deleted the betas server and has migrated it to their main server, I've updated it (on behalf of Abuse) so it responds with a brief explanation on how to access the betas and invites them to the server where the betas are currently are, and that's their main/support server or whatever they really call it.