### PR TITLE
update patcher guide commands

### DIFF
--- a/files/guides/patcher.md
+++ b/files/guides/patcher.md
@@ -8,10 +8,15 @@ https://discord.gg/sk1er
 
 # Patcher - How do I use it?
 
-The commands for patcher are:
-> /patcher, /patcher sounds, /patcher name, /patcher blacklist, /patcher benchmark, /patcher debugfps, /patcher vanilla/optimized (useless), /fov, /sendcoords, /invscale
+The main commands for patcher is:
+> /patcher
 
-From there on you will be greeted with a peculiar GUI (see image below) or with tips on how to use the command.
+The other commands for patcher are:
+> /patcher blacklist, /patcher fov, /patcher fps, /patcher scale, /patcher invscale, /patcher inventoryscale, /patcher name, /patcher names, /patcher namehistory, /patcher sendcoords, /patcher sounds, /patcher help
+
+Use the help command to see the usage of all these extra commands.
+
+After using the main command, you will be greeted with a peculiar GUI (see image below).
 
 ![image of the GUI](https://raw.githubusercontent.com/nacrt/SkyblockClient-REPO/main/files/guides/images/PatcherGUI.png)
 
@@ -21,5 +26,3 @@ You can navigate the settings using the Menu on the left
 In the top right you can find a small magnifying glass. Hover over it and you can search for features:
 
 ![image of top right](https://raw.githubusercontent.com/nacrt/SkyblockClient-REPO/main/files/guides/images/PatcherSearch.png)
-
-


### PR DESCRIPTION
Changes and explanations:
- Many of the old commands that are no longer present have been removed (straightforward)
- A few of the extra commands (such as `/patcher sounds` and `/patcher scale/invscale/inventoryscale`) are accessible through the /patcher config GUI and it makes more sense to have people find those rather than the use the commands
- Most people won't ever use most of the extra commands, they shouldn't be labeled as "main".
- The line "From there on you will be greeted with a peculiar GUI (see image below) or with tips on how to use the command." was confusing and didn't explain what did what, and frankly was just straight-up wrong. For example, `/sendcoords` would just paste the user's coords in chat. It never brought up any GUI or explained what it did. `/patcher help` should be the main subcommand advertised, which is why I added a small note.