### PR TITLE
new furfsky website link

### DIFF
--- a/files/packs.json
+++ b/files/packs.json
@@ -454,7 +454,7 @@
             {
                 "icon": "furfskywebsite.png",
                 "text": "Website",
-                "link": "https://furfsky.github.io/"
+                "link": "https://furfsky.net/"
             }
         ],
         "categories": [


### PR DESCRIPTION
furfskys website moved from https://furfsky.github.io/ to https://furfsky.net/ -> https://github.com/furfsky/next