### PR TITLE
Changed apec link from skyclient pages to github release

### DIFF
--- a/files/mods.json
+++ b/files/mods.json
@@ -872,7 +872,7 @@
         "categories": ["2;All Skyblock"],
         "file": "apec-1.11.6.jar",
         "files": ["config/Apec/Settings.txt"],
-        "url": "https://skyclient-files.pages.dev/apec-1.11.6.jar",
+        "url": "https://github.com/BananaFructa/Apec/releases/download/1.11.6/apec-1.11.6.jar",
         "forge_id": "apec",
         "hash": "3765996d7f1ccc508604c4ba860e13f5"
     },


### PR DESCRIPTION
Why was it skyclient pages? it was the same hash???