### PR TITLE
Add BedWar Mod to mods list

### DIFF
--- a/files/mods.json
+++ b/files/mods.json
@@ -2421,10 +2421,10 @@
             }
         ],
         "categories": ["6;Recommended PvP"],
-        "file": "BedWar-0.1.6.jar",
-        "url": "https://cdn.modrinth.com/data/Al95W2SE/versions/gN9IzWLz/BedWar-0.1.6.jar",
+        "file": "BedWar-0.1.7.Pre.1.jar",
+        "url": "https://cdn.modrinth.com/data/Al95W2SE/versions/2R3ft4oU/BedWar-0.1.7.Pre.1.jar",
         "forge_id": "bedwar",
-        "hash": "099d830f10e6f5c316fffbf3f6c79a9f"
+        "hash": "bf6923222c6dc32a81a355c2fd6a254f"
     },
     {
         "id": "minecraft",

--- a/files/mods.json
+++ b/files/mods.json
@@ -2404,6 +2404,29 @@
         "hash": "b8dd0265174daf4647b1016600597d6b"
     },
     {
+        "id": "bedwar",
+        "display": "BedWar Mod",
+        "creator": "CalMWolfs",
+        "description": "A mod which provides some utilities for Hypixel Bedwars",
+        "actions": [
+            {
+                "icon": "github.png",
+                "text": "GitHub",
+                "link": "https://github.com/BedWarMod/BedWar"
+            },
+            {
+                "icon": "modrinth.png",
+                "text": "Modrinth",
+                "link": "https://modrinth.com/mod/bedwar-mod"
+            }
+        ],
+        "categories": ["6;Recommended PvP"],
+        "file": "BedWar-0.1.6.jar",
+        "url": "https://cdn.modrinth.com/data/Al95W2SE/versions/gN9IzWLz/BedWar-0.1.6.jar",
+        "forge_id": "bedwar",
+        "hash": "099d830f10e6f5c316fffbf3f6c79a9f"
+    },
+    {
         "id": "minecraft",
         "display": "no",
         "creator": "Mojang",


### PR DESCRIPTION
Add my BedWars mod to the SkyClient modlist
Provides a few useful displays and features for playing BedWars that are not found in other forge mods