### PR TITLE
Removed API key description - not needed anymore

### DIFF
--- a/files/guides/dsm.md
+++ b/files/guides/dsm.md
@@ -19,11 +19,6 @@ Tells you the amount of players on skyblock.
 > /loot <zombie/spider/wolf/fishing/catacombs>
 
 Returns loot quantites from slayers/fishing/dungeons.
-> /setkey
-
-> /getkey
-
-Sets api key/copies it.
 > /display <zombie/spider/wolf/fishing/catacombs/auto/off>
 
 Displays loot trackers.

--- a/files/guides/skytils.md
+++ b/files/guides/skytils.md
@@ -13,9 +13,6 @@ Open the mod's config menu - turn on features and solvers.
 > /skytils help
 
 See all of the mod's commands.
-> /skytils setkey [key]
-
-Sets your API key (will also grab it from /api new).
 > /skytils reload <aliases/data>
 
 Forces Skytils to re-fetch command aliases or solutions from the data repository.

--- a/files/guides/wyvtils.md
+++ b/files/guides/wyvtils.md
@@ -3,9 +3,6 @@
 ## How do I use Wyvtils?
 > to enable and disable features, type in either `/wyvtils` or `/wyvtil` in chat. Then configure the settings there. 
 
-## Some features require an API key (such as the GEXP and winstreak command).
-> to add an API key, either type in `/api new` in chat, or type in `/wyvtils setkey [key]`.
-
 ### How do I get support for Wyvtils?
 > to get support for Wyvtils, go to the Polyfrost discord server (https://inv.wtf/polyfrost) and type your issue / send a crash log in the #support channel.
 


### PR DESCRIPTION
Removed API key descriptions as people on the discord kept asking about whether skyclient was outdated